### PR TITLE
chore: add --quiet flag to nix commands in CI

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -19,7 +19,7 @@ jobs:
         with:
           cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - name: Build library
-        run: nix build
+        run: nix build --quiet
   unit:
     name: Run unit Tests
     runs-on: ubuntu-latest
@@ -29,7 +29,7 @@ jobs:
         with:
           cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - name: Run Tests
-        run: nix run .#unit-tests
+        run: nix run --quiet .#unit-tests
   formatting:
     name: Check code formatting
     runs-on: ubuntu-latest
@@ -39,4 +39,4 @@ jobs:
         with:
           cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - name: Check Formatting
-        run: nix develop -c just format-check
+        run: nix develop --quiet -c just format-check

--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -17,4 +17,4 @@ jobs:
       - uses: paolino/dev-assets/setup-nix@v0.0.1
         with:
           cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
-      - run: nix develop github:paolino/dev-assets?dir=mkdocs -c mkdocs gh-deploy --force
+      - run: nix develop --quiet github:paolino/dev-assets?dir=mkdocs -c mkdocs gh-deploy --force


### PR DESCRIPTION
## Summary

Add `--quiet` flag to all nix commands in CI workflows to reduce log noise.

## Changes

- `CI.yaml`: Add `--quiet` to `nix build`, `nix run`, and `nix develop`
- `deploy-docs.yaml`: Add `--quiet` to `nix develop`

## Test plan

- [ ] CI passes with reduced output