### PR TITLE
docs: snapshot isolation and speculation

### DIFF
--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,11 +2,12 @@
 
 ## Design Philosophy
 
-The library is built around three core principles:
+The library is built around four core principles:
 
 1. **Type Safety** - Column keys and values are typed at compile time
 2. **Modularity** - Backend-agnostic abstractions with RocksDB implementation
 3. **Composability** - Transaction operations compose monadically
+4. **Snapshot Isolation** - All reads within a transaction see a consistent point-in-time view
 
 ## Component Diagram
 
@@ -14,6 +15,7 @@ The library is built around three core principles:
 graph TB
     subgraph "Application Layer"
         TX[Transaction Monad]
+        SPEC[Speculation]
         CUR[Cursor Operations]
     end
 
@@ -26,14 +28,17 @@ graph TB
     subgraph "Storage Layer"
         ROCKS[RocksDB Backend]
         CF[Column Families]
+        SNAP[Snapshots]
     end
 
     TX --> DB
+    SPEC --> DB
     CUR --> DB
     DB --> COL
     COL --> COD
     DB --> ROCKS
     ROCKS --> CF
+    ROCKS --> SNAP
 ```
 
 ## Library Structure

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,9 @@ Type-safe key-value transactions backed by RocksDB.
 This library provides a transactional layer over RocksDB with:
 
 - **Type-safe columns** - Each column has its own key and value types, enforced at compile time
+- **Snapshot isolation** - All reads within a transaction see a consistent point-in-time view
 - **Atomic transactions** - Buffered writes are applied atomically on commit
+- **Speculation** - Read-your-writes transactions that discard mutations, for computing derived results
 - **Cursor iteration** - Range queries with forward/backward navigation
 - **Serialization via Prisms** - Flexible encoding/decoding using lens prisms
 


### PR DESCRIPTION
## Summary

- Document snapshot isolation in transaction architecture
- Add speculation section with sequence diagram
- Update API reference with `runSpeculation` and `withSnapshot`
- Update overview with snapshot isolation principle
- Update index features list